### PR TITLE
Enable horizontal scrolling for sequence diagrams

### DIFF
--- a/src/ui/App.scss
+++ b/src/ui/App.scss
@@ -104,6 +104,10 @@
   //background-color: #2b2b2b;
 }
 
+.sequence-diagram {
+  overflow-x: auto;
+}
+
 .buttons:not(:last-child) {
   margin-bottom: 0 !important;
 }

--- a/src/ui/SequenceDiagram.js
+++ b/src/ui/SequenceDiagram.js
@@ -150,7 +150,7 @@ export class SequenceDiagram extends Component {
         const sequenceDiagram = this.props.sequenceDiagram;
         return (
             <div>
-                <div ref={this.sequenceDiagramRef} dangerouslySetInnerHTML={{__html: sequenceDiagram}}/>
+                <div ref={this.sequenceDiagramRef} className="sequence-diagram" dangerouslySetInnerHTML={{__html: sequenceDiagram}}/>
                 {this.popup()}
             </div>
         )


### PR DESCRIPTION
Fix for [issue 25](https://github.com/kensa-dev/kensa/issues/25).

Test reproducing the original non-scrolling behaviour: https://github.com/michaelomichael/kensa-example-1

After applying this fix, the SVG can be scrolled horizontally.

Scrolled to the left:
![image](https://github.com/kensa-dev/kensa/assets/10383044/ef314210-9547-4fc7-b8d8-40e319927020)

Scrolled to the right:
![image](https://github.com/kensa-dev/kensa/assets/10383044/f68a5af5-50e9-4181-8712-abbefb9b338f)

Tested in Chrome (121.0.6167.85 Official Build x86_64), Firefox (121.0.1 64-bit), and Safari (17.3 - 17617.2.4.11.11, 17617) on OSX.

