### PR TITLE
Add floating headers to sequence diagrams

### DIFF
--- a/src/ui/App.scss
+++ b/src/ui/App.scss
@@ -89,6 +89,7 @@
 
 .sequence-diagram {
   overflow-x: auto;
+  position: relative;
 }
 
 .buttons:not(:last-child) {

--- a/src/ui/test/invocation/tabs/SequenceDiagram.js
+++ b/src/ui/test/invocation/tabs/SequenceDiagram.js
@@ -1,8 +1,10 @@
+import "./sequence-diagram.scss";
 import React, {createRef, useEffect, useState} from "react";
 import {InteractionPopup} from "./interaction/InteractionPopup";
 
 export const SequenceDiagram = ({capturedInteractions, highlights, sequenceDiagram}) => {
     const sequenceDiagramRef = createRef();
+    const sequenceDiagramHeaderRef = createRef();
     const [interaction, setInteraction] = useState(null);
 
     const clickableChildrenOf = (parent) => {
@@ -26,24 +28,78 @@ export const SequenceDiagram = ({capturedInteractions, highlights, sequenceDiagr
 
     const hidePopup = () => setInteraction(null)
 
+    const addFloatingHeader = () => {
+        const originalSvg = sequenceDiagramRef.current.querySelector('svg');
+        const newSvg = originalSvg.cloneNode(true);
+
+        // Remove all SVG elements except the top row of <rects> and <text>s
+        newSvg.querySelectorAll('line, .sequence_diagram_clickable, path, polygon').forEach(element => element.remove());
+        newSvg.querySelectorAll('rect:first-child, rect:nth-last-child(2), text:last-child').forEach(element => element.remove());
+        newSvg.querySelectorAll('text, rect').forEach((element, idx) => { if (idx % 4 >= 2) element.remove() } );
+
+        const firstRect = newSvg.querySelector('rect')
+        const headerHeight = (parseInt(firstRect.getAttribute('y'))*2) + parseInt(firstRect.getAttribute('height'));
+
+        newSvg.style.height = `${headerHeight}px`;
+        newSvg.setAttribute('viewBox', newSvg.getAttribute('viewBox').split(' ').with(3, `${headerHeight}`).join(' '));
+        newSvg.setAttribute('height', `${headerHeight}px`);
+
+        sequenceDiagramHeaderRef.current.appendChild(newSvg);
+        sequenceDiagramHeaderRef.current.setAttribute('height', `${headerHeight}`);
+
+        sequenceDiagramRef.current.ownerDocument.addEventListener('scroll', updateFloatingHeaderPosition);
+    }
+
+    /// Using `position: sticky` doesn't work reliably in any browser when any ancestor has `overflow-x: auto` :(
+    const updateFloatingHeaderPosition = () => {
+        const windowHeight = window.innerHeight;
+        const windowScrollTop = window.scrollY;
+
+        const diagramContainer = sequenceDiagramRef.current;
+        const diagramContainerTop = diagramContainer.offsetTop
+        const diagramContainerHeight = diagramContainer.offsetHeight
+
+        const header = sequenceDiagramHeaderRef.current;
+        const headerHeight = parseInt(header.getAttribute('height'));
+
+        const diagramIsTooBigToFitOnScreen = windowHeight < diagramContainerHeight;
+        const userHasReachedDiagram = windowScrollTop >= diagramContainerTop;
+        const userHasNotScrolledPastDiagram = windowScrollTop < diagramContainerTop + diagramContainerHeight - (headerHeight*2);
+
+        if (diagramIsTooBigToFitOnScreen && userHasReachedDiagram && userHasNotScrolledPastDiagram) {
+            header.style.top = `${windowScrollTop - diagramContainerTop}px`;
+            header.style.display = 'block';
+        }
+        else
+        {
+            header.style.display = 'none';
+        }
+    }
+
     useEffect(() => {
-        const clickableNodes = clickableChildrenOf(sequenceDiagramRef.current.firstElementChild);
+        const sequenceDiagram = sequenceDiagramRef.current;
+        const clickableNodes = clickableChildrenOf(sequenceDiagram);
 
         clickableNodes.forEach(node => {
             node.addEventListener('click', onClick);
         })
 
+        addFloatingHeader();
+
         return () => {
             clickableNodes.forEach(node => {
                 node.removeEventListener('click', onClick);
             })
+
+            sequenceDiagram.ownerDocument.removeEventListener('scroll', updateFloatingHeaderPosition);
         }
     }, []);
 
     return <>
-        <div ref={sequenceDiagramRef}
-             className="sequence-diagram"
-             dangerouslySetInnerHTML={{__html: sequenceDiagram}}/>
+        <div ref={sequenceDiagramRef} className="sequence-diagram">
+            <div ref={sequenceDiagramHeaderRef} className="sequence-diagram-header"></div>
+            <div dangerouslySetInnerHTML={{__html: sequenceDiagram}}/>
+        </div>
         {
             interaction &&
             <InteractionPopup onHide={hidePopup}

--- a/src/ui/test/invocation/tabs/sequence-diagram.scss
+++ b/src/ui/test/invocation/tabs/sequence-diagram.scss
@@ -1,0 +1,8 @@
+@import "../../../bulma-custom";
+
+.sequence-diagram-header {
+  opacity: 0.6;
+  position: absolute;
+  display: none;
+}
+


### PR DESCRIPTION
When scrolling down in a very large sequence diagrams the names of the actors/swimlanes aren't visible. 

This makes the diagram extremely hard to read, especially if you have a lot of actors, so it's nice to have the actor names "float" at the top of the screen while the diagram scrolls.

Example:
https://github.com/user-attachments/assets/cdf5a1f6-7b82-416d-b4b7-92943c1c7f8b



