### PR TITLE
Display the test class's package as part of the header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(libs.junitJupiterParams)
     implementation(libs.junitJupiterApi)
     implementation(libs.junitJupiterEngine)
+    implementation(libs.junitPlatformLauncher)
     implementation(libs.assertJCore)
     implementation(libs.hamcrestCore)
     implementation(libs.awaitilityKotlin)

--- a/src/main/java/dev/kensa/Kensa.kt
+++ b/src/main/java/dev/kensa/Kensa.kt
@@ -3,6 +3,7 @@ package dev.kensa
 import dev.kensa.Kensa.KENSA_DISABLE_OUTPUT
 import dev.kensa.Kensa.KENSA_OUTPUT_DIR
 import dev.kensa.Kensa.KENSA_OUTPUT_ROOT
+import dev.kensa.PackageDisplayMode.HideCommonPackages
 import dev.kensa.Section.*
 import dev.kensa.render.*
 import dev.kensa.render.diagram.directive.UmlDirective
@@ -119,10 +120,20 @@ object Kensa {
     fun withTabSize(tabSize: Int): Kensa = apply {
         configuration.tabSize = tabSize
     }
-
+    
     fun withFlattenOutputPackages(value: Boolean): Kensa = apply {
         configuration.flattenOutputPackages = value
     }
+    
+    fun withPackageDisplayMode(packageDisplayMode: PackageDisplayMode): Kensa = apply {
+        configuration.packageDisplayMode = packageDisplayMode
+    }
+}
+
+enum class PackageDisplayMode {
+    Hidden,
+    HideCommonPackages,
+    ShowFullPackage,
 }
 
 enum class Section {
@@ -157,6 +168,7 @@ class Configuration {
     var issueTrackerUrl: URL = defaultIssueTrackerUrl()
     var tabSize: Int = 5
     var autoOpenTab: Tab = Tab.None
+    var packageDisplayMode: PackageDisplayMode = HideCommonPackages
 
     var setupStrategy: SetupStrategy = SetupStrategy.Ungrouped
 

--- a/src/main/java/dev/kensa/context/TestContainer.kt
+++ b/src/main/java/dev/kensa/context/TestContainer.kt
@@ -13,7 +13,8 @@ class TestContainer(
     val methods: Map<Method, TestMethodContainer>,
     val notes: String?,
     val issues: List<String>,
-    private val testWriter: TestWriter
+    val minimumUniquePackageName: String,
+    private val testWriter: TestWriter,
 ) : CloseableResource {
     val state: TestState
         get() = methods.values

--- a/src/main/java/dev/kensa/context/TestContainerFactory.kt
+++ b/src/main/java/dev/kensa/context/TestContainerFactory.kt
@@ -12,7 +12,7 @@ import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Method
 
 class TestContainerFactory {
-    fun createFor(context: ExtensionContext, testWriter: TestWriter): TestContainer =
+    fun createFor(context: ExtensionContext, testWriter: TestWriter, commonBasePackage: String = ""): TestContainer =
         context.requiredTestClass.run {
             TestContainer(
                 this,
@@ -20,6 +20,7 @@ class TestContainerFactory {
                 createMethodContainers(),
                 notes(),
                 issues(),
+                deriveMinimumUniquePackageName(commonBasePackage),
                 testWriter
             )
         }
@@ -48,4 +49,14 @@ class TestContainerFactory {
     private fun AnnotatedElement.notes(): String? = findAnnotation<Notes>()?.value
 
     private fun AnnotatedElement.issues(): List<String> = findAnnotation<Issue>()?.value?.toList() ?: emptyList()
+
+    private fun <T> Class<T>.deriveMinimumUniquePackageName(commonBasePackage: String): String =
+        commonBasePackage
+            .takeIf { it.isNotBlank() and packageName.startsWith(it) }
+            ?.let { packageName.replaceFirst(it, "") }
+            ?.removeLeadingDots()
+            ?: packageName
+
+    private fun String.removeLeadingDots() =
+        replace(Regex("^\\.+"), "")
 }

--- a/src/main/java/dev/kensa/junit/KensaExtension.kt
+++ b/src/main/java/dev/kensa/junit/KensaExtension.kt
@@ -32,7 +32,7 @@ class KensaExtension : Extension, BeforeAllCallback, BeforeEachCallback,
         if (Kensa.configuration.isOutputEnabled) {
             with(context.getStore(KENSA)) {
                 val executionContext = bindToRootContextOf(context)
-                val container = testContainerFactory.createFor(context, DefaultTestWriter(Kensa.configuration))
+                val container = testContainerFactory.createFor(context, DefaultTestWriter(Kensa.configuration), TestPlanDetails.commonBasePackage) 
                 put(TEST_CONTAINER_KEY, container)
                 executionContext.register(container)
             }

--- a/src/main/java/dev/kensa/junit/KensaTestExecutionListener.kt
+++ b/src/main/java/dev/kensa/junit/KensaTestExecutionListener.kt
@@ -1,0 +1,36 @@
+package dev.kensa.junit
+
+import dev.kensa.util.findCommonPackage
+import org.junit.platform.engine.support.descriptor.ClassSource
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestIdentifier
+import org.junit.platform.launcher.TestPlan
+
+/**
+ * Shares data between the Launcher's TestExecutionListener and
+ * the KensaExtension.
+ */
+object TestPlanDetails {
+    var commonBasePackage: String = ""
+}
+
+class KensaTestExecutionListener : TestExecutionListener {
+    override fun testPlanExecutionStarted(testPlan: TestPlan?) {
+        testPlan?.also {
+            TestPlanDetails.commonBasePackage = determineCommonBasePackageFor(it)
+        } 
+    }
+
+    private fun determineCommonBasePackageFor(testPlan: TestPlan): String = 
+        testPlan
+            .roots
+            .asSequence()
+            .flatMap(testPlan::getChildren)
+            .filter(TestIdentifier::isContainer)
+            .filter { it.source.isPresent }
+            .map { it.source.get() }
+            .filterIsInstance<ClassSource>()
+            .map { it.javaClass.packageName }
+            .toList()
+            .let(::findCommonPackage)
+}

--- a/src/main/java/dev/kensa/output/json/JsonTransforms.kt
+++ b/src/main/java/dev/kensa/output/json/JsonTransforms.kt
@@ -30,6 +30,7 @@ object JsonTransforms {
             .add("displayName", container.classDisplayName)
             .add("state", container.state.description)
             .add("notes", container.notes)
+            .add("minimumUniquePackageName", container.minimumUniquePackageName)
             .add("issues", asJsonArray(container.issues))
             .add("tests", asJsonArray(container.methods.values) { invocation: TestMethodContainer ->
                 var totalElapsed: Duration = Duration.ZERO

--- a/src/main/java/dev/kensa/output/template/Template.kt
+++ b/src/main/java/dev/kensa/output/template/Template.kt
@@ -109,6 +109,7 @@ sealed class FileTemplate(mode: Mode, configuration: Configuration, private val 
                         .add("issueTrackerUrl", issueTrackerUrl.toString())
                         .add("acronyms", acronymsAsJson(acronyms))
                         .add("flattenPackages", flattenOutputPackages)
+                        .add("packageDisplayMode", packageDisplayMode.name)
                         .add("sectionOrder", Json.array().apply {
                             sectionOrder.forEach { add(it.name) }
                         })

--- a/src/main/java/dev/kensa/util/PackageUtils.kt
+++ b/src/main/java/dev/kensa/util/PackageUtils.kt
@@ -1,0 +1,19 @@
+package dev.kensa.util
+
+typealias PackageElements = List<String>
+
+internal fun findCommonPackage(packageNames: List<String>): String {
+    require(packageNames.isNotEmpty())
+
+    return packageNames
+        .map { it.toPackageElements() }
+        .reduce(PackageElements::commonBaseWith)
+        .joinToString(".")
+}
+
+private fun String.toPackageElements(): PackageElements = split(".")
+
+private fun PackageElements.commonBaseWith(other: PackageElements): PackageElements = 
+    zip(other)
+        .takeWhile { pairAtIndex -> pairAtIndex.first == pairAtIndex.second }
+        .map { entry -> entry.first }

--- a/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+dev.kensa.junit.KensaTestExecutionListener

--- a/src/test/java/dev/kensa/context/TestContainerFactoryTest.kt
+++ b/src/test/java/dev/kensa/context/TestContainerFactoryTest.kt
@@ -4,7 +4,9 @@ import dev.kensa.Kensa
 import dev.kensa.output.DefaultTestWriter
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.maps.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
@@ -50,6 +52,50 @@ internal class TestContainerFactoryTest {
 
         result.methods.filterValues { it.displayName == "Test 7" }.shouldNotBeEmpty()
     }
+    
+    @Nested
+    inner class MinimumUniquePackageName {
+
+        @Test
+        internal fun `selects empty package name when commonBasePackage matches fully`() {
+            val testClass: Class<*> = TestClass::class.java
+
+            whenever(extensionContext.requiredTestClass).thenReturn(testClass)
+            val result = factory.createFor(extensionContext, DefaultTestWriter(Kensa.configuration), "dev.kensa.context")
+
+            result.minimumUniquePackageName shouldBe ""
+        }
+
+        @Test
+        internal fun `selects partial package name when commonBasePackage matches partially`() {
+            val testClass: Class<*> = TestClass::class.java
+
+            whenever(extensionContext.requiredTestClass).thenReturn(testClass)
+            val result = factory.createFor(extensionContext, DefaultTestWriter(Kensa.configuration), "dev.kensa")
+
+            result.minimumUniquePackageName shouldBe "context"
+        }
+
+        @Test
+        internal fun `keeps original package name when commonBasePackage does not match at all`() {
+            val testClass: Class<*> = TestClass::class.java
+
+            whenever(extensionContext.requiredTestClass).thenReturn(testClass)
+            val result = factory.createFor(extensionContext, DefaultTestWriter(Kensa.configuration), "something.else")
+
+            result.minimumUniquePackageName shouldBe "dev.kensa.context"
+        }
+        
+        @Test
+        internal fun `keeps original package name when commonBasePackage is empty`() {
+            val testClass: Class<*> = TestClass::class.java
+
+            whenever(extensionContext.requiredTestClass).thenReturn(testClass)
+            val result = factory.createFor(extensionContext, DefaultTestWriter(Kensa.configuration), "")
+
+            result.minimumUniquePackageName shouldBe "dev.kensa.context"
+        }
+    }
 
     private interface TestInterface {
         @Test
@@ -57,7 +103,7 @@ internal class TestContainerFactoryTest {
         }
     }
 
-    @Suppress("UNUSED_PARAMETER")
+    @Suppress("UNUSED_PARAMETER", "JUnitMalformedDeclaration", "RedundantVisibilityModifier")
     private class TestClass : TestInterface {
         @Test
         fun test1() {

--- a/src/test/java/dev/kensa/context/TestContainerTest.kt
+++ b/src/test/java/dev/kensa/context/TestContainerTest.kt
@@ -16,7 +16,8 @@ class TestContainerTest {
             emptyMap(),
             null,
             emptyList(),
-            writer
+            javaClass.packageName,
+            writer,
         )
 
         container.close()

--- a/src/test/java/dev/kensa/util/PackageUtilsTest.kt
+++ b/src/test/java/dev/kensa/util/PackageUtilsTest.kt
@@ -1,0 +1,75 @@
+package dev.kensa.util
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class PackageUtilsTest {
+    
+    @Nested
+    inner class EmptyPackageList {
+        @Test
+        internal fun `throws when no packages are provided`() {
+            assertThrows<Exception> {
+                findCommonPackage(emptyList())
+            }
+        }
+    }
+    
+    @Nested
+    inner class SingleLevelPackages {
+        @Test
+        internal fun `returns the same package when only one is provided`() {
+            findCommonPackage(listOf("foo")) shouldBe "foo"
+        }
+        
+        @Test
+        internal fun `returns the same package when all are identical`() {
+            findCommonPackage(listOf("foo", "foo", "foo")) shouldBe "foo"
+        }
+
+        @Test
+        internal fun `returns empty string when there is no common package`() {
+            findCommonPackage(listOf("foo", "bar")) shouldBe ""
+        }
+    }
+    
+    @Nested
+    inner class MultiLevelPackages {
+        @Test
+        internal fun `returns the same package when only one is provided`() {
+            findCommonPackage(listOf("aaa.bbb.ccc")) shouldBe "aaa.bbb.ccc"
+        }
+        
+        @Test
+        internal fun `returns the same package when all are identical`() {
+            findCommonPackage(listOf("aaa.bbb.ccc", "aaa.bbb.ccc", "aaa.bbb.ccc")) shouldBe "aaa.bbb.ccc"
+        }
+
+        @Test
+        internal fun `returns empty string when there is no common package`() {
+            findCommonPackage(listOf("aaa1.bbb.ccc", "aaa2.bbb.ccc", "aaa3.bbb.ccc")) shouldBe ""
+        }
+        
+        @Test
+        internal fun `returns common package when it is the root package`() {
+            findCommonPackage(listOf("aaa", "aaa.bbb1.ccc", "aaa.bbb2.ccc", "aaa.bbb2.ccc", "aaa")) shouldBe "aaa"
+        }
+        
+        @Test
+        internal fun `returns common package when it is a second-level package with multiple distinct children`() {
+            findCommonPackage(listOf("aaa.bbb.ccc1", "aaa.bbb.ccc2", "aaa.bbb.ccc3", "aaa.bbb")) shouldBe "aaa.bbb"
+        }
+        
+        @Test
+        internal fun `returns common package when it is a second-level package with only one child`() {
+            findCommonPackage(listOf("aaa.bbb.ccc", "aaa.bbb", "aaa.bbb")) shouldBe "aaa.bbb"
+        }
+        
+        @Test
+        internal fun `returns common package when it is a third-level package`() {
+            findCommonPackage(listOf("aaa.bbb.ccc.ddd1", "aaa.bbb.ccc.ddd2", "aaa.bbb.ccc.ddd3", "aaa.bbb.ccc")) shouldBe "aaa.bbb.ccc"
+        }
+    }
+}

--- a/src/ui/Header.js
+++ b/src/ui/Header.js
@@ -3,14 +3,16 @@ import React from "react";
 import './Header.scss';
 import './App.scss';
 
-const Header = ({headerText, headerClass}) => {
+const Header = ({headerClass, children}) => {
     return (
         <section className={"header " + headerClass}>
             <div className="header-body">
                 <a href={"index.html"}>
                     <Logo className="logo"/>
                 </a>
-                <h1 className="header-title">{headerText}</h1>
+                <h1 className="header-title">
+                    {children}
+                </h1>
             </div>
         </section>
     )

--- a/src/ui/Header.scss
+++ b/src/ui/Header.scss
@@ -25,7 +25,9 @@
 
 .header-title {
   @extend .title;
-  margin-left: 20px
+  margin-left: 20px;
+  display: flex;
+  flex-direction: column;
 }
 
 .logo {

--- a/src/ui/index/Index.js
+++ b/src/ui/index/Index.js
@@ -92,7 +92,7 @@ const Index = () => {
            onClick={() => setUrl({...filter, state: state})}>{text}</a>
 
     return <>
-        <Header headerText={"Index"} headerClass={"is-info is-light"}/>
+        <Header headerClass={"is-info is-light"}>Index</Header>
         <section className="section">
             <nav className="block">
                 <div className="field has-addons">

--- a/src/ui/test/PackageName.js
+++ b/src/ui/test/PackageName.js
@@ -1,0 +1,48 @@
+import React from "react";
+import './PackageName.scss';
+
+const PackageName = ({fullPackageName, minimumUniquePackageName, packageDisplayMode}) => {
+    
+    const removeSuffix = (text, suffix) => suffix?.length > 0 ? text?.slice(0, -suffix.length) : text;
+    const commonPackageName = () => removeSuffix(fullPackageName, minimumUniquePackageName);
+    const withArrows = (packageName) => packageName.replaceAll(".", " > ");
+    
+    const title = `Package: ${fullPackageName}`;
+    
+    switch (packageDisplayMode) {
+        case "Hidden":
+            return null;
+            
+        case "HideCommonPackages":
+            return minimumUniquePackageName 
+                ? (
+                    <div className="test-class-package-name" title={title}>
+                        <span className="unique-package-name">{withArrows(minimumUniquePackageName)}</span>
+                    </div>
+                )
+                : null;
+            
+        case "ShowFullPackage":
+            if (fullPackageName.endsWith(minimumUniquePackageName)) {
+                return (
+                    <div className="test-class-package-name" title={title}>
+                        <span className="common-package-name">{withArrows(commonPackageName())}</span>
+                        <span className="unique-package-name">{withArrows(minimumUniquePackageName)}</span>
+                    </div>
+                );
+
+            } else {
+                return (
+                    <div className="test-class-package-name" title={title}>
+                        <span className="full-package-name">{withArrows(fullPackageName)}</span>
+                    </div>
+                );
+            }
+
+        default:
+            console.warn("Unexpected value for data.packageDisplayMode:", packageDisplayMode);
+            return null;
+    }
+}
+
+export default PackageName;

--- a/src/ui/test/PackageName.scss
+++ b/src/ui/test/PackageName.scss
@@ -1,0 +1,8 @@
+.test-class-package-name {
+  font-size: 0.75rem;
+  font-weight: normal;
+}
+
+.common-package-name {
+  opacity: 0.5;
+}

--- a/src/ui/test/TestClass.js
+++ b/src/ui/test/TestClass.js
@@ -1,10 +1,12 @@
-import React, {useEffect, useState} from "react";
-import {stateClassFor} from "../Util";
+import React, {useContext, useEffect, useState} from "react";
+import {ConfigContext, stateClassFor} from "../Util";
 import Test from "./Test";
 import Information from "./information/Information";
 import Header from "../Header";
+import PackageName from "./PackageName";
 
 const TestClass = () => {
+    const {packageDisplayMode} = useContext(ConfigContext)
     const [data, setData] = useState(null);
     const [startExpanded, setStartExpanded] = useState(0);
 
@@ -19,11 +21,16 @@ const TestClass = () => {
 
         setData(data)
     }, [])
-
+    
+    const packageNameFromClass = (fqClassName) => fqClassName.replace(/\.[^.]+$/, "")
+     
     if (data) {
         return (
             <>
-                <Header headerText={data.displayName} headerClass={stateClassFor(data.state)}/>
+                <Header headerClass={stateClassFor(data.state)}>
+                    <PackageName packageDisplayMode={packageDisplayMode} fullPackageName={packageNameFromClass(data.testClass)} minimumUniquePackageName={data.minimumUniquePackageName}/>
+                    {data.displayName}                        
+                </Header>
                 <section className="section">
                     <Information issues={data.issues} notes={data.notes}/>
                     {


### PR DESCRIPTION
Obviously class names should have unique names which fully and clearly explain their exact scope, but that rarely happens in my experience! 

Time and again, I've found myself navigating to the browser's address bar and manually scrolling across to see the package name in order to get the necessary context for the test class that I'm looking at on-screen. (The package name almost always requires some horizontal scrolling before it is visible.)

This PR is my suggestion for a way of displaying the salient parts of the Test class's package on-screen.

It may not be to everyone's taste, so I'm happy to accept suggestions regarding the functionality, appearance, and the choice of default setting. 😄 


## Configuration
The behaviour can be controlled by setting `Kensa.withPackageDisplayMode(PackageDisplayMode)`. 

The following sections show some examples of how it looks for each of the different `PackageDisplayMode` values, based on the following example test class structure:
```
dev.kensa.example.packageA.packageB.packageC.TestWithLargeSequenceDiagram.java
dev.kensa.example.packageA.packageX.TestWithSingleFailingTest.java
dev.kensa.example.packageA.TestWithMultiplePassingTest.java
```


### With `packageDisplayMode = Hidden`: 
Does not show package names at all. (Legacy behivour.)
<img width="875" alt="Hidden with long package" src="https://github.com/user-attachments/assets/ed74c286-084e-4205-b636-8ecfe25447e8" />
<img width="874" alt="Hidden with medium-length package" src="https://github.com/user-attachments/assets/18cac998-2ebf-48b8-b54c-4258bff7d27f" />
<img width="877" alt="Hidden with shortest package" src="https://github.com/user-attachments/assets/43e24084-1ff1-4848-bc1d-355d341b2889" />





### With `packageDisplayMode = HideCommonPackages`: 
Displays the package, but strips off any root packages that are common to every test that was run. In the example above, all Test classes' packages start with `dev.kensa.example.packageA` so it'll display the remainder of each Test class's package without the `dev.kensa.example.packageA` prefix. 

**I'm proposing this as the default behaviour.**

<img width="877" alt="Partial with long package" src="https://github.com/user-attachments/assets/552b6899-27b3-48d6-b57e-6fe5300e6e15" />
<img width="877" alt="Partial with medium-length package" src="https://github.com/user-attachments/assets/117e9c70-d213-46cf-bee8-58d08e0c8df0" />
<img width="876" alt="Partial with shortest package" src="https://github.com/user-attachments/assets/107c0477-bc99-44cb-b8a6-3f56223023d7" />



### With `packageDisplayMode = ShowFullPackage`: 
Displays the full package, with common root packages slightly dimmed.
<img width="877" alt="Full with long package" src="https://github.com/user-attachments/assets/c36d5298-42b5-4693-a28e-51a5b7fb3382" />
<img width="877" alt="Full with medium-length package" src="https://github.com/user-attachments/assets/14ff4255-588c-4fd1-974d-1ea95231c2b6" />
<img width="877" alt="Full with shortest package" src="https://github.com/user-attachments/assets/64fbf970-15bd-406d-82b4-be681bcd3703" />

