### PR TITLE
Value class params in expandable sentence

### DIFF
--- a/compiler/compiler-plugin/src/test/kotlin/dev/kensa/compiler/ExpandableSentenceIntegrationTest.kt
+++ b/compiler/compiler-plugin/src/test/kotlin/dev/kensa/compiler/ExpandableSentenceIntegrationTest.kt
@@ -6,6 +6,7 @@ import dev.kensa.context.RealExpandableInvocation
 import dev.kensa.parse.MethodParameters
 import dev.kensa.parse.ParsedExpandableMethod
 import example.ExpandableSentences
+import example.MyValueClass
 import example.Service
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -30,6 +31,7 @@ class ExpandableSentenceIntegrationTest {
             expandableCase("doubleParam", invoke = { instance.doubleParam(1.5) }, args = listOf(1.5), service = service),
             expandableCase("charParam", invoke = { instance.charParam('z') }, args = listOf('z'), service = service),
             expandableCase("expressionBody", invoke = { instance.expressionBody("e") }, args = listOf("e"), service = service),
+            expandableCase("valueClassParam", invoke = { instance.valueClassParam(MyValueClass("test arg")) }, args = listOf(MyValueClass("test arg")), service = service),
             expandableCase(
                 "onExtensionReceiver",
                 invoke = { with(instance) { "ext".onExtensionReceiver() } },

--- a/compiler/compiler-plugin/src/test/kotlin/dev/kensa/compiler/ExpandableSentenceIntegrationTest.kt
+++ b/compiler/compiler-plugin/src/test/kotlin/dev/kensa/compiler/ExpandableSentenceIntegrationTest.kt
@@ -39,6 +39,18 @@ class ExpandableSentenceIntegrationTest {
                 service = service
             ),
             expandableCase(
+                "onExtensionReceiverWithValueClassParam",
+                invoke = { with(instance) { "ext".onExtensionReceiverWithValueClassParam(MyValueClass("test arg")) } },
+                args = listOf("ext", MyValueClass("test arg")),
+                service = service
+            ),
+            expandableCase(
+                "onValueClassExtensionReceiverWithValueClassParam",
+                invoke = { with(instance) { MyValueClass("receiver").onValueClassExtensionReceiverWithValueClassParam(MyValueClass("test arg")) } },
+                args = listOf(MyValueClass("receiver"), MyValueClass("test arg")),
+                service = service
+            ),
+            expandableCase(
                 "withContextParameter",
                 invoke = { with("p") { instance.withContextParameter("v") } },
                 args = listOf("p", "v"),

--- a/compiler/compiler-plugin/src/testFixtures/kotlin/example/Fixtures.kt
+++ b/compiler/compiler-plugin/src/testFixtures/kotlin/example/Fixtures.kt
@@ -19,6 +19,9 @@ interface Service {
     fun call(args: Array<Any>)
 }
 
+@JvmInline
+value class MyValueClass(val value: String)
+
 class ExpandableSentences(private val service: Service) {
     @ExpandableSentence
     fun foo(bar: String) {
@@ -56,6 +59,11 @@ class ExpandableSentences(private val service: Service) {
     @ExpandableSentence
     fun String.onExtensionReceiver() {
         service.call(arrayOf(this))
+    }
+
+    @ExpandableSentence
+    fun valueClassParam(value: MyValueClass) {
+        service.call(arrayOf(value))
     }
 
     context(prefix: String)

--- a/compiler/compiler-plugin/src/testFixtures/kotlin/example/Fixtures.kt
+++ b/compiler/compiler-plugin/src/testFixtures/kotlin/example/Fixtures.kt
@@ -66,6 +66,16 @@ class ExpandableSentences(private val service: Service) {
         service.call(arrayOf(value))
     }
 
+    @ExpandableSentence
+    fun String.onExtensionReceiverWithValueClassParam(value: MyValueClass) {
+        service.call(arrayOf(this, value))
+    }
+
+    @ExpandableSentence
+    fun MyValueClass.onValueClassExtensionReceiverWithValueClassParam(value: MyValueClass) {
+        service.call(arrayOf(this, value))
+    }
+
     context(prefix: String)
     @ExpandableSentence
     fun withContextParameter(suffix: String) {

--- a/core/src/hooks/kotlin/dev/kensa/runtime/CompilerPluginHookFunctions.kt
+++ b/core/src/hooks/kotlin/dev/kensa/runtime/CompilerPluginHookFunctions.kt
@@ -2,7 +2,10 @@ package dev.kensa.runtime
 
 import dev.kensa.context.ExpandableInvocationContextHolder
 import dev.kensa.context.RenderedValueInvocationContextHolder
+import dev.kensa.util.allMethods
 import dev.kensa.util.findMethod
+import dev.kensa.util.normalisedPlatformName
+import dev.kensa.util.originalParamTypes
 import java.lang.reflect.Method
 import kotlin.reflect.KClass
 
@@ -26,6 +29,10 @@ object CompilerPluginHookFunctions {
             else -> owner::class.java
         }
 
-        return clazz.findMethod(simpleName, *paramTypes.map { it.java }.toTypedArray())
+        return clazz
+            .allMethods
+            .firstOrNull { it.normalisedPlatformName == simpleName && it.originalParamTypes contentEquals paramTypes }
+            // Fallback to the original findMethod call, which doesn't know about methods with "value class" parameters
+            ?: clazz.findMethod(simpleName, *paramTypes.map { it.java }.toTypedArray())
     }
 }

--- a/core/src/main/kotlin/dev/kensa/context/ExpandableInvocationContext.kt
+++ b/core/src/main/kotlin/dev/kensa/context/ExpandableInvocationContext.kt
@@ -2,6 +2,7 @@ package dev.kensa.context
 
 import dev.kensa.parse.ElementDescriptor
 import dev.kensa.parse.ParsedExpandableMethod
+import dev.kensa.util.normalisedPlatformName
 import java.lang.reflect.Method
 
 class ExpandableInvocationContext {
@@ -11,7 +12,7 @@ class ExpandableInvocationContext {
     private val invocations = mutableMapOf<String, MutableList<Array<Any?>>>()
 
     fun recordInvocation(method: Method, args: Array<Any?>) {
-        invocations.compute(method.name) { _, current ->
+        invocations.compute(method.normalisedPlatformName) { _, current ->
             current?.also { it.add(args) } ?: mutableListOf(args)
         }
     }

--- a/core/src/main/kotlin/dev/kensa/parse/MethodParser.kt
+++ b/core/src/main/kotlin/dev/kensa/parse/MethodParser.kt
@@ -9,6 +9,9 @@ import dev.kensa.util.*
 import java.lang.reflect.Method
 import kotlin.collections.emptyList
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.jvm.kotlinFunction
 
 class ClassDeclarations(
     val imports: Imports,
@@ -138,12 +141,14 @@ class MethodParser(
     private fun Class<*>.findExpandableMethod(dc: MethodDeclarationContext, imports: Imports): Method =
         allMethods.filter { it.normalisedPlatformName == dc.name }
             .find { method ->
-                val syntheticCount = method.findSyntheticKotlinReceivers().size
-                val totalMethodParams = method.parameterTypes.size
+                val realMethodParams = method
+                    .kotlinFunction
+                    ?.parameters
+                    ?.filter { it.kind == KParameter.Kind.VALUE }
+                    ?.map { it.type.jvmErasure.java }
+                    ?.toTypedArray()
+                    ?: method.parameterTypes
 
-                if (totalMethodParams != syntheticCount + dc.parameterTypes.size) return@find false
-
-                val realMethodParams = method.parameterTypes.drop(syntheticCount).toTypedArray()
                 imports.match(realMethodParams, dc.parameterTypes)
             } ?: throw KensaException("Did not find expandable method [${dc.name}] in class [${this.name}]")
 

--- a/core/src/main/kotlin/dev/kensa/util/Reflect.kt
+++ b/core/src/main/kotlin/dev/kensa/util/Reflect.kt
@@ -12,6 +12,7 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.function.Supplier
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KTypeProjection
@@ -26,6 +27,18 @@ val Class<*>.isKotlinObject get() = isKotlinClass && kotlin.objectInstance != nu
 val KClass<*>.isKotlinObject get() = isKotlinClass && objectInstance != null
 
 val Method.normalisedPlatformName: String get() = takeIf { declaringClass.isKotlinClass }?.kotlinFunction?.name ?: name
+
+/**
+ * Returns the parameter types (including context parameters and extension receiver, if present) as they would have
+ * been declared in Kotlin, before any <code>value class</code> parameters were inlined to their underlying types.
+ */
+val Method.originalParamTypes: Array<KClass<*>>
+    get() = this.kotlinFunction
+        ?.parameters
+        ?.filter { it.kind != KParameter.Kind.INSTANCE }
+        ?.mapNotNull { it.type.classifier as? KClass<*> }
+        ?.toTypedArray()
+        ?: this.parameterTypes.map { it.kotlin }.toTypedArray()
 
 fun Method.derivedTestName(protectedPhrases: Collection<String>): String =
     takeIf { declaringClass.isKotlinClass }
@@ -192,7 +205,7 @@ internal fun Class<*>.findRequiredField(name: String) = this.findField(withField
 
 internal fun Any.fieldValue(name: String): Any? = this::class.java.findRequiredField(name).valueOfIn(this)
 
-internal val Class<*>.allMethods get() = findMethodsInHierarchy(allTheMethods)
+val Class<*>.allMethods get() = findMethodsInHierarchy(allTheMethods)
 internal val Class<*>.allProperties: Set<KProperty<*>> get() = kotlin.allProperties
 internal val KClass<*>.allProperties: Set<KProperty<*>> get() = memberProperties.toSet() + findStaticPropertiesInHierarchy()
 internal val Class<*>.allFields get() = findFieldsInHierarchy(allTheFields)

--- a/frameworks/junit/junit5/src/kotlinTest/resources/kotlin/KotlinWithExpandableSentenceTest_result.json
+++ b/frameworks/junit/junit5/src/kotlinTest/resources/kotlin/KotlinWithExpandableSentenceTest_result.json
@@ -1636,6 +1636,62 @@
           "displayName": "[2] two"
         }
       ]
+    },
+    {
+      "elapsedTime": "",
+      "testMethod": "testForExpandableSentenceWithValueClassParameter",
+      "displayName": "Test For Expandable Sentence With Value Class Parameter",
+      "issues": [],
+      "tags": [],
+      "state": "Passed",
+      "autoOpenTab": "None",
+      "invocations": [
+        {
+          "elapsedTime": "",
+          "highlights": [],
+          "sentences": [
+            {
+              "lineNumber": 175,
+              "tokens": [
+                {
+                  "types": [
+                    "tk-ex"
+                  ],
+                  "value": "some Action With Value Class Parameter",
+                  "parameterTokens": [
+                    {
+                      "types": [
+                        "tk-id"
+                      ],
+                      "value": "myValueClassInstance"
+                    }
+                  ],
+                  "tokens": [
+                    [
+                      {
+                        "types": [
+                          "tk-wd"
+                        ],
+                        "value": "some action with parameter 1 value"
+                      }
+                    ]
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [],
+          "capturedInteractions": [],
+          "capturedOutputs": [],
+          "fixtures": [],
+          "fixtureSpecs": [],
+          "sequenceDiagram": null,
+          "componentDiagram": null,
+          "state": "Passed",
+          "executionException": {},
+          "displayName": "testForExpandableSentenceWithValueClassParameter()"
+        }
+      ]
     }
   ]
 }

--- a/frameworks/junit/shared-examples/kotlinExample/kotlin/dev/kensa/example/KotlinWithExpandableSentenceTest.kt
+++ b/frameworks/junit/shared-examples/kotlinExample/kotlin/dev/kensa/example/KotlinWithExpandableSentenceTest.kt
@@ -170,6 +170,18 @@ class KotlinWithExpandableSentenceTest : KotlinExampleTest(), WithHamkrest, Inte
         return someOtherAction("anAction")
     }
 
+    @Test
+    fun testForExpandableSentenceWithValueClassParameter() {
+        someActionWithValueClassParameter(myValueClassInstance)
+    }
+
+    @ExpandableSentence
+    fun someActionWithValueClassParameter(parameter1: MyValueClass): Action<ActionContext> {
+        return someActionWith(parameter1.value)
+    }
+
+    private val myValueClassInstance = MyValueClass("foo")
+
     private fun someOtherAction(withAParam: String): Action<ActionContext> {
         return Action { }
     }
@@ -183,3 +195,6 @@ interface InterfaceWithExpandableSentence {
 
     private fun someActionWith(@RenderedValue parameter1: String): Action<ActionContext> = Action { }
 }
+
+@JvmInline
+value class MyValueClass(val value: String)

--- a/frameworks/junit/shared-examples/kotlinExample/resources/kotlin/KotlinWithExpandableSentenceTest_result.json
+++ b/frameworks/junit/shared-examples/kotlinExample/resources/kotlin/KotlinWithExpandableSentenceTest_result.json
@@ -1636,6 +1636,62 @@
           "displayName": "[2] \"two\""
         }
       ]
+    },
+    {
+      "elapsedTime": "",
+      "testMethod": "testForExpandableSentenceWithValueClassParameter",
+      "displayName": "Test For Expandable Sentence With Value Class Parameter",
+      "issues": [],
+      "tags": [],
+      "state": "Passed",
+      "autoOpenTab": "None",
+      "invocations": [
+        {
+          "elapsedTime": "",
+          "highlights": [],
+          "sentences": [
+            {
+              "lineNumber": 175,
+              "tokens": [
+                {
+                  "types": [
+                    "tk-ex"
+                  ],
+                  "value": "some Action With Value Class Parameter",
+                  "parameterTokens": [
+                    {
+                      "types": [
+                        "tk-id"
+                      ],
+                      "value": "myValueClassInstance"
+                    }
+                  ],
+                  "tokens": [
+                    [
+                      {
+                        "types": [
+                          "tk-wd"
+                        ],
+                        "value": "some action with parameter 1 value"
+                      }
+                    ]
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [],
+          "capturedInteractions": [],
+          "capturedOutputs": [],
+          "fixtures": [],
+          "fixtureSpecs": [],
+          "sequenceDiagram": null,
+          "componentDiagram": null,
+          "state": "Passed",
+          "executionException": {},
+          "displayName": "testForExpandableSentenceWithValueClassParameter()"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Kensa fails to find methods annotated with `@ExpandableSentence` when one or more of their parameters is a Kotlin value class:
```
Kensa was unable to parse this test. This usually means the test contains syntax that the parser does not yet handle.
Please copy the details below (together with some example code) and report them at https://github.com/kensa-dev/kensa/issues so we can fix it.
--- Error ---
Did not find expandable method [someAction] in class [com.example.ExpandableSentenceTest]
--- End ---
```

Very simple example that can trigger the problem:
```
@JvmInline
value class Foo(val value: String)

val myValueClassInstance = Foo("test")

@ExpandableSentence
fun someAction(param: Foo): Action<ActionContext> = {
    println("Do something with ${param.value}")
}

@Test
fun exampleTest() {
    whenever(someAction(myValueClassInstance))
    then(someStateCollector()) { }
}
```

The test output renders normally if you remove the `@ExpandableSentence` annotation, or change the parameter from `Foo` to `String`.

The issue is that the Kotlin compiler will append a hash to the method name so that the JVM can distinguish between e.g. `fun someAction(param:Foo)` and `someAction(param:String)` - the former's signature will appear to the JVM as `void someAction-abc123(String param)` - so we have to jump through a few hoops to get back to the original method name and parameter types.

I've made changes to `CompilerPluginHookFunctions` and `MethodParser`, and made sure to keep more generic fallback methods, but let me know if you think there's a better approach.