### PR TITLE
Display empty strings correctly in invocation parameter matrix

### DIFF
--- a/ui/src/util/paramValueClassifier.test.ts
+++ b/ui/src/util/paramValueClassifier.test.ts
@@ -3,13 +3,6 @@ import { classifyParamValue } from './paramValueClassifier';
 
 describe('classifyParamValue', () => {
     describe('null-ish', () => {
-        it('classifies empty string as null', () => {
-            const result = classifyParamValue('');
-            expect(result.kind).toBe('null');
-            expect(result.displayValue).toBe('null');
-            expect(result.className).toContain('italic');
-        });
-
         it('classifies "null" as null', () => {
             const result = classifyParamValue('null');
             expect(result.kind).toBe('null');
@@ -95,6 +88,13 @@ describe('classifyParamValue', () => {
     });
 
     describe('strings', () => {
+        it('classifies empty string as string', () => {
+            const result = classifyParamValue('');
+            expect(result.kind).toBe('string');
+            expect(result.displayValue).toBe('""');
+            expect(result.className).toContain('text-emerald-600');
+        });
+
         it('wraps a plain string in quotes', () => {
             const result = classifyParamValue('hello');
             expect(result.kind).toBe('string');

--- a/ui/src/util/paramValueClassifier.ts
+++ b/ui/src/util/paramValueClassifier.ts
@@ -15,7 +15,7 @@ const STRING_CLASS = 'text-emerald-600';
 const NUMBER_RE = /^-?\d+(\.\d+)?$/;
 
 export function classifyParamValue(raw: string): ClassifiedValue {
-    if (raw === '' || raw === 'null' || raw === 'undefined') {
+    if (raw === 'null' || raw === 'undefined') {
         return { kind: 'null', displayValue: 'null', className: NULL_CLASS };
     }
     if (NUMBER_RE.test(raw)) {


### PR DESCRIPTION
Displays empty string parameter values as `""` in the table at the top of the test, rather than `null`.

### Example
My test was invoked several times, sometimes passing in `null` and sometimes passing in `""` as parameter values, but both cases always displayed misleadingly as `null` in the table:
<img width="1444" height="225" alt="before" src="https://github.com/user-attachments/assets/b71a4f24-cab3-4639-acb3-dcf0d386ab1c" />

This PR fixes it so the empty strings appear as `""`, to distinguish them from a genuine `null` value:
<img width="1444" height="227" alt="after" src="https://github.com/user-attachments/assets/f6609b11-c5a6-486c-a5e2-6f55d3cf109e" />
