### PR TITLE
Fix browser crash when @Highlight value is empty string

### DIFF
--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { buildHighlightRegex } from './utils';
+
+describe('buildHighlightRegex', () => {
+    it('matches each highlight', () => {
+        const regex = buildHighlightRegex(['alice', 'bob']);
+
+        expect('hello alice and bob'.split(regex)).toEqual(['hello ', 'alice', ' and ', 'bob', '']);
+    });
+
+    it('escapes regex metacharacters in a highlight', () => {
+        const regex = buildHighlightRegex(['a.b']);
+
+        expect(regex.test('axb')).toBe(false);
+        expect(buildHighlightRegex(['a.b']).test('a.b')).toBe(true);
+    });
+
+    it('ignores empty highlights, keeping the rest', () => {
+        const regex = buildHighlightRegex(['', 'bob']);
+
+        expect('hello bob'.split(regex)).toEqual(['hello ', 'bob', '']);
+    });
+
+    // An empty highlight used to match at every position, splitting each text node into empty
+    // fragments and hanging the browser tab.
+    it('never matches when every highlight is empty', () => {
+        const regex = buildHighlightRegex(['']);
+
+        expect(regex.test('a null value')).toBe(false);
+        expect('a null value'.split(regex)).toEqual(['a null value']);
+    });
+
+    it('never matches when there are no highlights', () => {
+        const regex = buildHighlightRegex([]);
+
+        expect(regex.test('a null value')).toBe(false);
+        expect('a null value'.split(regex)).toEqual(['a null value']);
+    });
+});

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -96,12 +96,14 @@ export function getAllTextNodes(root: Node): Text[] {
     return textNodes;
 }
 
-export function buildHighlightRegex(highlights: string[]): RegExp | null {
+export function buildHighlightRegex(highlights: string[]): RegExp {
     const escaped = highlights
-        .map(h => h.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'))
-        .filter(h => h.length > 0);
+        .filter(h => h.length > 0)
+        .map(h => h.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'));
 
-    if (escaped.length == 0) return null;
+    // An empty highlight matches at every position, so every text node splits into empty fragments and
+    // the tab hangs. `(?!)` can never match, leaving callers to render the text untouched.
+    if (escaped.length === 0) return /(?!)/g;
 
     return new RegExp(`(${escaped.join('|')})`, 'g');
 }
@@ -121,8 +123,6 @@ export function applyKensaHighlights(root: HTMLElement, highlights: string[], cl
     if (highlights.length === 0) return;
 
     const regExp = buildHighlightRegex(highlights);
-
-    if (regExp == null) return;
 
     getAllTextNodes(root).forEach(node => {
         const text = node.textContent ?? '';

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -96,8 +96,13 @@ export function getAllTextNodes(root: Node): Text[] {
     return textNodes;
 }
 
-export function buildHighlightRegex(highlights: string[]): RegExp {
-    const escaped = highlights.map(h => h.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'));
+export function buildHighlightRegex(highlights: string[]): RegExp | null {
+    const escaped = highlights
+        .map(h => h.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'))
+        .filter(h => h.length > 0);
+
+    if (escaped.length == 0) return null;
+
     return new RegExp(`(${escaped.join('|')})`, 'g');
 }
 
@@ -116,6 +121,8 @@ export function applyKensaHighlights(root: HTMLElement, highlights: string[], cl
     if (highlights.length === 0) return;
 
     const regExp = buildHighlightRegex(highlights);
+
+    if (regExp == null) return;
 
     getAllTextNodes(root).forEach(node => {
         const text = node.textContent ?? '';


### PR DESCRIPTION
Having a field/parameter annotated with `@Highlight` can cause the browser tab to crash when the value of that field/parameter is an empty string (`""`).

This is because the generated "highlight" regex pattern will match every single text node due to it matching on the empty string.

This fix ignores any zero-length "highlight" values.