### PR TITLE
Type-check the UI in CI

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -20,6 +20,19 @@ tasks {
         dependsOn("npmInstall")
     }
 
+    // vite transpiles through esbuild, which strips types without checking them, so nothing else in the
+    // build would catch a type error.
+    register<NodeTask>("typeCheck") {
+        script.set(project.file("node_modules/.bin/tsc"))
+        args = listOf("--noEmit")
+
+        inputs.file("tsconfig.json")
+        inputs.file("tsconfig.node.json")
+        inputs.file("package-lock.json")
+        inputs.dir("src")
+        dependsOn("npmInstall")
+    }
+
     register<NodeTask>("viteBuild") {
         script.set(project.file("node_modules/.bin/vite"))
         args = listOf("build")
@@ -28,7 +41,7 @@ tasks {
         inputs.file("package-lock.json")
         inputs.dir("src")
         outputs.dir("${layout.buildDirectory.get()}/js")
-        dependsOn("npmInstall", "viteTest")
+        dependsOn("npmInstall", "typeCheck", "viteTest")
     }
 
     register<NodeTask>("viteDev") {


### PR DESCRIPTION
`viteBuild` shells straight to vite, which transpiles through esbuild and strips types without checking them, so the `tsc` half of the npm build script never ran in CI.

Adds a `typeCheck` task running `tsc --noEmit` and puts it ahead of `viteBuild`.

Verified it actually gates: reintroducing the `RegExp | null` return from #186 fails the task with the two `TS2769` errors that previously passed CI.

Fixes #187